### PR TITLE
Introduce

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,33 @@ A lightweight authorization proxy for Model Context Protocol (MCP) servers that 
 
 ![Architecture Diagram](https://github.com/user-attachments/assets/41cf6723-c488-4860-8640-8fec45006f92)
 
-## What it Does
-
-Open MCP Auth Proxy sits between MCP clients and your MCP server to:
+## What it Does?
 
 - Intercept incoming requests
 - Validate authorization tokens
 - Offload authentication and authorization to OAuth-compliant Identity Providers
 - Support the MCP authorization protocol
 
-## Quick Start
+
+## 🚀 Features
+
+- **Dynamic Authorization** based on MCP Authorization Specification (v1 and v2).
+- **JWT Validation** (signature, audience, and scopes).
+- **Identity Provider Integration** (OAuth/OIDC via Asgardeo, Auth0, Keycloak).
+- **Protocol Version Negotiation** via `MCP-Protocol-Version` header.
+- **Comprehensive Authentication Feedback** via RFC-compliant challenges.
+- **Flexible Transport Modes**: SSE and stdio.
+
+## 📌 MCP Specification Verions
+
+| Version | Date                  | Behavior                                                                                                                                                                                                                                                                                                                                                                                   |
+| :------ | :-------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **v1**  | *before* 2025-03-26   | Only signature check of Bearer JWT on both `/sse` and `/message`<br> No scope or audience enforcement                                                                                                                                                                                                                                                                                   |
+| **v2**  | *on/after* 2025-03-26 | Read `MCP-Protocol-Version` from client header<br> SSE handshake returns `WWW-Authenticate: Bearer resource_metadata="…"`<br> `/message` enforces:<br>   1. `aud` claim == `ResourceIdentifier`<br>   2. `scope` claim contains per-path `requiredScope`<br>   3. PolicyEngine decision<br> Rich `WWW-Authenticate` on 401s<br> Serves `/​.well-known/oauth-protected-resource` JSON |
+
+> ⚠️ **Note:** MCP v2 support is available **only in SSE mode**. The stdio mode supports only v1.
+
+## 🛠️ Quick Start
 
 ### Prerequisites
 
@@ -67,7 +84,7 @@ Open MCP Auth Proxy sits between MCP clients and your MCP server to:
 
 3. Connect using an MCP client like [MCP Inspector](https://github.com/shashimalcse/inspector)(This is a temporary fork with fixes for authentication [issues](https://github.com/modelcontextprotocol/typescript-sdk/issues/257) in the original implementation)
 
-## Connect an Identity Provider
+## 🔒 Integrate an Identity Provider
 
 ### Asgardeo
 
@@ -88,6 +105,20 @@ asgardeo:
   org_name: "<org_name>"                      # Your Asgardeo org name
   client_id: "<client_id>"                    # Client ID of the M2M app
   client_secret: "<client_secret>"            # Client secret of the M2M app
+
+  # Only required if you are using the latest version of the MCP specification
+  resource_identifier: "http://localhost:8080" # URL of the MCP proxy server
+  authorization_servers:
+    - "https://example.idp.com" # Base URL of the identity provider
+  jwks_uri: "https://example.idp.com/.well-known/jwks.json"
+  bearer_methods_supported:
+    - header
+    - body
+    - query
+    # Protect the MCP endpoints with per-path scopes:
+  scopes_supported:
+    "/message": "mcp_proxy:message"
+    "/resources/list": "mcp_proxy:read"
 ```
 
 4. Start the proxy with Asgardeo integration:
@@ -101,7 +132,7 @@ asgardeo:
 - [Auth0](docs/integrations/Auth0.md)
 - [Keycloak](docs/integrations/keycloak.md)
 
-# Advanced Configuration
+# ⚙️ Advanced Configuration
 
 ### Transport Modes
 
@@ -167,7 +198,7 @@ The proxy will:
 - Handle all authorization requirements
 - Forward messages between clients and the server
 
-### Complete Configuration Reference
+### 📝 Complete Configuration Reference
 
 ```yaml
 # Common configuration
@@ -214,9 +245,21 @@ asgardeo:
   org_name: "<org_name>"
   client_id: "<client_id>"
   client_secret: "<client_secret>"
+  # Required according to the latest MCP specification
+  resource_identifier: "http://localhost:8080"
+  scopes_supported:
+    "/get-alerts": "mcp_proxy"
+    "/get-forecast": "mcp_proxy"
+  authorization_servers:
+    - "https://dev-3l9-ppfg.us.auth0.com"
+  jwks_uri: "https://dev-3l9-ppfg.us.auth0.com/.well-known/jwks.json"
+  bearer_methods_supported:
+    - header
+    - body
+    - query
 ```
 
-### Build from source
+### 🖥️ Build from source
 
 ```bash
 git clone https://github.com/wso2/open-mcp-auth-proxy

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -93,7 +93,7 @@ func main() {
 	}
 
 	// 5. (Optional) Build the policy engine
-	engine := &authz.DefaulPolicyEngine{}
+	engine := &authz.DefaultPolicyEngine{}
 
 	// 6. Build the main router
 	mux := proxy.NewRouter(cfg, provider, engine)

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -92,12 +92,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	// 5. Build the main router
-	mux := proxy.NewRouter(cfg, provider)
+	// 5. (Optional) Build the policy engine
+	engine := &authz.DefaulPolicyEngine{}
+
+	// 6. Build the main router
+	mux := proxy.NewRouter(cfg, provider, engine)
 
 	listen_address := fmt.Sprintf(":%d", cfg.ListenPort)
 
-	// 6. Start the server
+	// 7. Start the server
 	srv := &http.Server{
 		Addr:    listen_address,
 		Handler: mux,
@@ -111,18 +114,18 @@ func main() {
 		}
 	}()
 
-	// 7. Wait for shutdown signal
+	// 8. Wait for shutdown signal
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 	<-stop
 	logger.Info("Shutting down...")
 
-	// 8. First terminate subprocess if running
+	// 9. First terminate subprocess if running
 	if procManager != nil && procManager.IsRunning() {
 		procManager.Shutdown()
 	}
 
-	// 9. Then shutdown the server
+	// 10. Then shutdown the server
 	logger.Info("Shutting down HTTP server...")
 	shutdownCtx, cancel := proxy.NewShutdownContext(5 * time.Second)
 	defer cancel()

--- a/config.yaml
+++ b/config.yaml
@@ -45,3 +45,16 @@ demo:
   org_name: "openmcpauthdemo"
   client_id: "N0U9e_NNGr9mP_0fPnPfPI0a6twa"
   client_secret: "qFHfiBp5gNGAO9zV4YPnDofBzzfInatfUbHyPZvM0jka"
+
+# Protected resource metadata
+resource_identifier: http://localhost:3000
+scopes_supported:
+  - get-alerts
+  - get-forecast
+authorization_servers:
+  - https://idp.example.com
+jwks_uri: https://idp.example.com/.well-known/jwks.json
+bearer_methods_supported:
+  - header
+  - body
+  - query

--- a/internal/authz/asgardeo.go
+++ b/internal/authz/asgardeo.go
@@ -336,3 +336,23 @@ func randomString(n int) string {
 	}
 	return string(b)
 }
+
+func (p *asgardeoProvider) ProtectedResourceMetadataHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		meta := map[string]interface{}{
+			"resource":              p.cfg.ResourceIdentifier,
+			"scopes_supported":      p.cfg.ScopesSupported,
+			"authorization_servers": p.cfg.AuthorizationServers,
+		}
+		if p.cfg.JwksURI != "" {
+			meta["jwks_uri"] = p.cfg.JwksURI
+		}
+		if len(p.cfg.BearerMethodsSupported) > 0 {
+			meta["bearer_methods_supported"] = p.cfg.BearerMethodsSupported
+		}
+		if err := json.NewEncoder(w).Encode(meta); err != nil {
+			http.Error(w, "failed to encode metadata", http.StatusInternalServerError)
+		}
+	}
+}

--- a/internal/authz/default.go
+++ b/internal/authz/default.go
@@ -99,6 +99,7 @@ func (p *defaultProvider) ProtectedResourceMetadataHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		meta := map[string]interface{}{
+			"audience": p.cfg.Audience,
 			"resource": p.cfg.ResourceIdentifier,
 			"scopes_supported": p.cfg.ScopesSupported,
 			"authorization_servers": p.cfg.AuthorizationServers,

--- a/internal/authz/default.go
+++ b/internal/authz/default.go
@@ -94,3 +94,26 @@ func (p *defaultProvider) WellKnownHandler() http.HandlerFunc {
 func (p *defaultProvider) RegisterHandler() http.HandlerFunc {
 	return nil
 }
+
+func (p *defaultProvider) ProtectedResourceMetadataHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		meta := map[string]interface{}{
+			"resource": p.cfg.ResourceIdentifier,
+			"scopes_supported": p.cfg.ScopesSupported,
+			"authorization_servers": p.cfg.AuthorizationServers,
+		}
+
+		if p.cfg.JwksURI != "" {
+			meta["jwks_uri"] = p.cfg.JwksURI
+		}
+
+		if len(p.cfg.BearerMethodsSupported) > 0 {
+			meta["bearer_methods_supported"] = p.cfg.BearerMethodsSupported
+		}
+
+		if err := json.NewEncoder(w).Encode(meta); err != nil {
+			http.Error(w, "failed to encode metadata", http.StatusInternalServerError)
+		}
+	}
+}

--- a/internal/authz/default_policy_engine.go
+++ b/internal/authz/default_policy_engine.go
@@ -1,0 +1,20 @@
+package authz
+
+import (
+	"net/http"
+)
+
+type TokenClaims struct {
+	Scopes []string
+}
+
+type DefaulPolicyEngine struct{}
+
+func (d *DefaulPolicyEngine) Evaluate(r *http.Request, claims *TokenClaims, requiredScope string) PolicyResult {
+	for _, scope := range claims.Scopes {
+		if scope == requiredScope {
+			return PolicyResult{DecisionAllow, ""}
+		}
+	}
+	return PolicyResult{DecisionDeny, "missing scope '" + requiredScope + "'"}
+}

--- a/internal/authz/policy.go
+++ b/internal/authz/policy.go
@@ -1,0 +1,19 @@
+package authz
+
+import "net/http"
+
+type Decision int
+
+const (
+    DecisionAllow Decision = iota
+    DecisionDeny
+)
+
+type PolicyResult struct {
+    Decision Decision
+    Message  string
+}
+
+type PolicyEngine interface {
+    Evaluate(r *http.Request, claims *TokenClaims, requiredScope string) PolicyResult
+}

--- a/internal/authz/provider.go
+++ b/internal/authz/provider.go
@@ -7,4 +7,5 @@ import "net/http"
 type Provider interface {
 	WellKnownHandler() http.HandlerFunc
 	RegisterHandler() http.HandlerFunc
+	ProtectedResourceMetadataHandler() http.HandlerFunc
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,7 @@ type Config struct {
 	Default  DefaultConfig  `yaml:"default"`
 
 	// Protected resource metadata
+	Audience               string   `yaml:"audience"`
 	ResourceIdentifier     string   `yaml:"resource_identifier"`
 	ScopesSupported        map[string]string `yaml:"scopes_supported"`
 	AuthorizationServers   []string `yaml:"authorization_servers"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,15 +17,15 @@ const (
 
 // Common path configuration for all transport modes
 type PathsConfig struct {
-	SSE       string `yaml:"sse"`
-	Messages  string `yaml:"messages"`
+	SSE      string `yaml:"sse"`
+	Messages string `yaml:"messages"`
 }
 
 // StdioConfig contains stdio-specific configuration
 type StdioConfig struct {
 	Enabled     bool     `yaml:"enabled"`
-	UserCommand string   `yaml:"user_command"` // The command provided by the user
-	WorkDir     string   `yaml:"work_dir"`     // Working directory (optional)
+	UserCommand string   `yaml:"user_command"`   // The command provided by the user
+	WorkDir     string   `yaml:"work_dir"`       // Working directory (optional)
 	Args        []string `yaml:"args,omitempty"` // Additional arguments
 	Env         []string `yaml:"env,omitempty"`  // Environment variables
 }
@@ -83,23 +83,31 @@ type DefaultConfig struct {
 }
 
 type Config struct {
-	AuthServerBaseURL  string
-	ListenPort         int           `yaml:"listen_port"`
-	BaseURL            string        `yaml:"base_url"`
-	Port               int           `yaml:"port"`
-	JWKSURL            string
-	TimeoutSeconds     int               `yaml:"timeout_seconds"`
-	PathMapping        map[string]string `yaml:"path_mapping"`
-	Mode               string            `yaml:"mode"`
-	CORSConfig         CORSConfig        `yaml:"cors"`
-	TransportMode      TransportMode     `yaml:"transport_mode"`
-	Paths              PathsConfig       `yaml:"paths"`
-	Stdio              StdioConfig       `yaml:"stdio"`
+	AuthServerBaseURL string
+	ListenPort        int    `yaml:"listen_port"`
+	BaseURL           string `yaml:"base_url"`
+	Port              int    `yaml:"port"`
+	JWKSURL           string
+	TimeoutSeconds    int               `yaml:"timeout_seconds"`
+	PathMapping       map[string]string `yaml:"path_mapping"`
+	Mode              string            `yaml:"mode"`
+	CORSConfig        CORSConfig        `yaml:"cors"`
+	TransportMode     TransportMode     `yaml:"transport_mode"`
+	Paths             PathsConfig       `yaml:"paths"`
+	Stdio             StdioConfig       `yaml:"stdio"`
+	RequiredScopes    map[string]string `yaml:"required_scopes"`
 
 	// Nested config for Asgardeo
 	Demo     DemoConfig     `yaml:"demo"`
 	Asgardeo AsgardeoConfig `yaml:"asgardeo"`
 	Default  DefaultConfig  `yaml:"default"`
+
+	// Protected resource metadata
+	ResourceIdentifier     string   `yaml:"resource_identifier"`
+	ScopesSupported        map[string]string `yaml:"scopes_supported"`
+	AuthorizationServers   []string `yaml:"authorization_servers"`
+	JwksURI                string   `yaml:"jwks_uri,omitempty"`
+	BearerMethodsSupported []string `yaml:"bearer_methods_supported,omitempty"`
 }
 
 // Validate checks if the config is valid based on transport mode
@@ -165,12 +173,12 @@ func LoadConfig(path string) (*Config, error) {
 	if err := decoder.Decode(&cfg); err != nil {
 		return nil, err
 	}
-	
+
 	// Set default values
 	if cfg.TimeoutSeconds == 0 {
 		cfg.TimeoutSeconds = 15 // default
 	}
-	
+
 	// Set default transport mode if not specified
 	if cfg.TransportMode == "" {
 		cfg.TransportMode = SSETransport // Default to SSE
@@ -180,11 +188,11 @@ func LoadConfig(path string) (*Config, error) {
 	if cfg.Port == 0 {
 		cfg.Port = 8000 // default
 	}
-	
+
 	// Validate the configuration
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
-	
+
 	return &cfg, nil
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,7 +1,14 @@
 package constants
 
+import "time"
+
 // Package constant provides constants for the MCP Auth Proxy
 
 const (
 	ASGARDEO_BASE_URL = "https://api.asgardeo.io/t/"
 )
+
+// MCP specification version cutover date
+var SpecCutoverDate = time.Date(2025, 3, 26, 0, 0, 0, 0, time.UTC)
+
+const TimeLayout = "2006-01-02"

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -10,14 +11,15 @@ import (
 
 	"github.com/wso2/open-mcp-auth-proxy/internal/authz"
 	"github.com/wso2/open-mcp-auth-proxy/internal/config"
-	"github.com/wso2/open-mcp-auth-proxy/internal/logging"
+	"github.com/wso2/open-mcp-auth-proxy/internal/constants"
+	logger "github.com/wso2/open-mcp-auth-proxy/internal/logging"
 	"github.com/wso2/open-mcp-auth-proxy/internal/util"
 )
 
 // NewRouter builds an http.ServeMux that routes
 // * /authorize, /token, /register, /.well-known to the provider or proxy
 // * MCP paths to the MCP server, etc.
-func NewRouter(cfg *config.Config, provider authz.Provider) http.Handler {
+func NewRouter(cfg *config.Config, provider authz.Provider, policyEngine authz.PolicyEngine) http.Handler {
 	mux := http.NewServeMux()
 
 	modifiers := map[string]RequestModifier{
@@ -55,6 +57,20 @@ func NewRouter(cfg *config.Config, provider authz.Provider) http.Handler {
 				defaultPaths = append(defaultPaths, "/.well-known/oauth-authorization-server")
 			}
 
+			mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+				origin := r.Header.Get("Origin")
+				allowed := getAllowedOrigin(origin, cfg)
+				if r.Method == http.MethodOptions {
+					addCORSHeaders(w, cfg, allowed, r.Header.Get("Access-Control-Request-Headers"))
+					w.WriteHeader(http.StatusNoContent)
+					return
+				}
+
+				addCORSHeaders(w, cfg, allowed, "")
+				provider.ProtectedResourceMetadataHandler()(w, r)
+			})
+			registeredPaths["/.well-known/oauth-protected-resource"] = true
+
 			defaultPaths = append(defaultPaths, "/authorize")
 			defaultPaths = append(defaultPaths, "/token")
 			defaultPaths = append(defaultPaths, "/register")
@@ -76,7 +92,7 @@ func NewRouter(cfg *config.Config, provider authz.Provider) http.Handler {
 
 	for _, path := range defaultPaths {
 		if !registeredPaths[path] {
-			mux.HandleFunc(path, buildProxyHandler(cfg, modifiers))
+			mux.HandleFunc(path, buildProxyHandler(cfg, modifiers, policyEngine))
 			registeredPaths[path] = true
 		}
 	}
@@ -84,14 +100,14 @@ func NewRouter(cfg *config.Config, provider authz.Provider) http.Handler {
 	// MCP paths
 	mcpPaths := cfg.GetMCPPaths()
 	for _, path := range mcpPaths {
-		mux.HandleFunc(path, buildProxyHandler(cfg, modifiers))
+		mux.HandleFunc(path, buildProxyHandler(cfg, modifiers, policyEngine))
 		registeredPaths[path] = true
 	}
 
 	// Register paths from PathMapping that haven't been registered yet
 	for path := range cfg.PathMapping {
 		if !registeredPaths[path] {
-			mux.HandleFunc(path, buildProxyHandler(cfg, modifiers))
+			mux.HandleFunc(path, buildProxyHandler(cfg, modifiers, policyEngine))
 			registeredPaths[path] = true
 		}
 	}
@@ -99,14 +115,14 @@ func NewRouter(cfg *config.Config, provider authz.Provider) http.Handler {
 	return mux
 }
 
-func buildProxyHandler(cfg *config.Config, modifiers map[string]RequestModifier) http.HandlerFunc {
+func buildProxyHandler(cfg *config.Config, modifiers map[string]RequestModifier, policyEngine authz.PolicyEngine) http.HandlerFunc {
 	// Parse the base URLs up front
 	authBase, err := url.Parse(cfg.AuthServerBaseURL)
 	if err != nil {
 		logger.Error("Invalid auth server URL: %v", err)
 		panic(err) // Fatal error that prevents startup
 	}
-	
+
 	mcpBase, err := url.Parse(cfg.BaseURL)
 	if err != nil {
 		logger.Error("Invalid MCP server URL: %v", err)
@@ -141,6 +157,10 @@ func buildProxyHandler(cfg *config.Config, modifiers map[string]RequestModifier)
 		// Add CORS headers to all responses
 		addCORSHeaders(w, cfg, allowedOrigin, "")
 
+		versionRaw := r.Header.Get("MCP-Protocol-Version")
+		ver, err := time.Parse(constants.TimeLayout, versionRaw)
+		isLatestSpec := err == nil && !ver.Before(constants.SpecCutoverDate)
+
 		// Decide whether the request should go to the auth server or MCP
 		var targetURL *url.URL
 		isSSE := false
@@ -148,13 +168,29 @@ func buildProxyHandler(cfg *config.Config, modifiers map[string]RequestModifier)
 		if isAuthPath(r.URL.Path) {
 			targetURL = authBase
 		} else if isMCPPath(r.URL.Path, cfg) {
-			// Validate JWT for MCP paths if required
-			// Placeholder for JWT validation logic
-			if err := util.ValidateJWT(r.Header.Get("Authorization")); err != nil {
-				logger.Warn("Unauthorized request to %s: %v", r.URL.Path, err)
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
+			if ssePaths[r.URL.Path] {
+				if err := authorizeSSE(w, r, isLatestSpec, cfg.ResourceIdentifier); err != nil {
+					http.Error(w, err.Error(), http.StatusUnauthorized)
+					return
+				}
+				isSSE = true
+			} else {
+				claims, err := authorizeMCP(w, r, isLatestSpec, cfg)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusUnauthorized)
+					return
+				}
+
+				if isLatestSpec {
+					scope := cfg.ScopesSupported[r.URL.Path]
+					pr := policyEngine.Evaluate(r, claims, scope)
+					if pr.Decision == authz.DecisionDeny {
+						http.Error(w, "Forbidden: "+pr.Message, http.StatusForbidden)
+						return
+					}
+				}
 			}
+
 			targetURL = mcpBase
 			if ssePaths[r.URL.Path] {
 				isSSE = true
@@ -214,7 +250,17 @@ func buildProxyHandler(cfg *config.Config, modifiers map[string]RequestModifier)
 			},
 			ModifyResponse: func(resp *http.Response) error {
 				logger.Debug("Response from %s%s: %d", resp.Request.URL.Host, resp.Request.URL.Path, resp.StatusCode)
-				resp.Header.Del("Access-Control-Allow-Origin") // Avoid upstream conflicts
+				if resp.StatusCode == http.StatusUnauthorized {
+					resp.Header.Set(
+						"WWW-Authenticate",
+						fmt.Sprintf(
+							`Bearer resource_metadata="%s"`,
+							cfg.ResourceIdentifier+"/.well-known/oauth-protected-resource",
+						))
+					resp.Header.Set("Access-Control-Expose-Headers", "WWW-Authenticate")
+				}
+
+				resp.Header.Del("Access-Control-Allow-Origin")
 				return nil
 			},
 			ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
@@ -236,7 +282,7 @@ func buildProxyHandler(cfg *config.Config, modifiers map[string]RequestModifier)
 			w.Header().Set("X-Accel-Buffering", "no")
 			w.Header().Set("Cache-Control", "no-cache")
 			w.Header().Set("Connection", "keep-alive")
-			
+			w.Header().Set("Content-Type", "text/event-stream")
 			// Keep SSE connections open
 			HandleSSE(w, r, rp)
 		} else {
@@ -246,6 +292,47 @@ func buildProxyHandler(cfg *config.Config, modifiers map[string]RequestModifier)
 			rp.ServeHTTP(w, r.WithContext(ctx))
 		}
 	}
+}
+
+// Check if the request is for SSE handshake and authorize it
+func authorizeSSE(w http.ResponseWriter, r *http.Request, isLatestSpec bool, resourceID string) error {
+	h := r.Header.Get("Authorization")
+	if !strings.HasPrefix(h, "Bearer ") {
+		if isLatestSpec {
+			realm := resourceID + "/.well-known/oauth-protected-resource"
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata="%s"`, realm))
+			w.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
+		}
+
+		return fmt.Errorf("missing bearer token")
+	}
+
+	return nil
+}
+
+// Handles both v1 (just signature) and v2 (aud + scope) flows
+func authorizeMCP(w http.ResponseWriter, r *http.Request, isLatestSpec bool, cfg *config.Config) (*authz.TokenClaims, error) {
+	h := r.Header.Get("Authorization")
+	audience := cfg.ResourceIdentifier
+	if isLatestSpec {
+		scope := cfg.ScopesSupported[r.URL.Path]
+		claims, err := util.ValidateJWT(r.Header.Get("MCP-Protocol-Version"), h, audience, scope)
+		if err != nil {
+			realm := audience + "/.well-known/oauth-protected-resource"
+			w.Header().Set("WWW-Authenticate",
+				fmt.Sprintf(`Bearer realm="%s", error="insufficient_scope", scope="%s"`, realm, scope))
+			w.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
+			return nil, err
+		}
+		return claims, nil
+	}
+
+	// v1: only check signature, then continue
+	if err := util.ValidateJWTOld(h); err != nil {
+		return nil, err
+	}
+
+	return &authz.TokenClaims{}, nil
 }
 
 func getAllowedOrigin(origin string, cfg *config.Config) string {
@@ -265,6 +352,7 @@ func getAllowedOrigin(origin string, cfg *config.Config) string {
 func addCORSHeaders(w http.ResponseWriter, cfg *config.Config, allowedOrigin, requestHeaders string) {
 	w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
 	w.Header().Set("Access-Control-Allow-Methods", strings.Join(cfg.CORSConfig.AllowedMethods, ", "))
+	w.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
 	if requestHeaders != "" {
 		w.Header().Set("Access-Control-Allow-Headers", requestHeaders)
 	} else {
@@ -283,6 +371,7 @@ func isAuthPath(path string) bool {
 		"/token":     true,
 		"/register":  true,
 		"/.well-known/oauth-authorization-server": true,
+		"/.well-known/oauth-protected-resource":   true,
 	}
 	if strings.HasPrefix(path, "/u/") {
 		return true

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -177,7 +177,7 @@ func buildProxyHandler(cfg *config.Config, modifiers map[string]RequestModifier,
 			} else {
 				claims, err := authorizeMCP(w, r, isLatestSpec, cfg)
 				if err != nil {
-					http.Error(w, err.Error(), http.StatusUnauthorized)
+					http.Error(w, err.Error(), http.StatusForbidden)
 					return
 				}
 
@@ -227,13 +227,13 @@ func buildProxyHandler(cfg *config.Config, modifiers map[string]RequestModifier,
 				req.Host = targetURL.Host
 
 				cleanHeaders := http.Header{}
-				
+
 				// Set proper origin header to match the target
 				if isSSE {
 					// For SSE, ensure origin matches the target
 					req.Header.Set("Origin", targetURL.Scheme+"://"+targetURL.Host)
 				}
-				
+
 				for k, v := range r.Header {
 					// Skip hop-by-hop headers
 					if skipHeader(k) {
@@ -277,7 +277,7 @@ func buildProxyHandler(cfg *config.Config, modifiers map[string]RequestModifier,
 				proxyHost:  r.Host,
 				targetHost: targetURL.Host,
 			}
-			
+
 			// Set SSE-specific headers
 			w.Header().Set("X-Accel-Buffering", "no")
 			w.Header().Set("Cache-Control", "no-cache")
@@ -296,15 +296,14 @@ func buildProxyHandler(cfg *config.Config, modifiers map[string]RequestModifier,
 
 // Check if the request is for SSE handshake and authorize it
 func authorizeSSE(w http.ResponseWriter, r *http.Request, isLatestSpec bool, resourceID string) error {
-	h := r.Header.Get("Authorization")
-	if !strings.HasPrefix(h, "Bearer ") {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
 		if isLatestSpec {
 			realm := resourceID + "/.well-known/oauth-protected-resource"
 			w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata="%s"`, realm))
 			w.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
 		}
-
-		return fmt.Errorf("missing bearer token")
+		return fmt.Errorf("missing or invalid Authorization header")
 	}
 
 	return nil
@@ -312,23 +311,31 @@ func authorizeSSE(w http.ResponseWriter, r *http.Request, isLatestSpec bool, res
 
 // Handles both v1 (just signature) and v2 (aud + scope) flows
 func authorizeMCP(w http.ResponseWriter, r *http.Request, isLatestSpec bool, cfg *config.Config) (*authz.TokenClaims, error) {
+	logger.Info("authorizeMCP")
 	h := r.Header.Get("Authorization")
 	audience := cfg.ResourceIdentifier
 	if isLatestSpec {
-		scope := cfg.ScopesSupported[r.URL.Path]
-		claims, err := util.ValidateJWT(r.Header.Get("MCP-Protocol-Version"), h, audience, scope)
+		required := cfg.ScopesSupported[r.URL.Path]
+		claims, err := util.ValidateJWT(r.Header.Get("MCP-Protocol-Version"), h, audience, required)
+		logger.Info("claims: %v", claims)
+		logger.Info("err: %v", err)
 		if err != nil {
-			realm := audience + "/.well-known/oauth-protected-resource"
-			w.Header().Set("WWW-Authenticate",
-				fmt.Sprintf(`Bearer realm="%s", error="insufficient_scope", scope="%s"`, realm, scope))
+			w.Header().Set(
+				"WWW-Authenticate",
+				fmt.Sprintf(
+					`Bearer realm="%s", error="insufficient_scope", scope="%s"`,
+					cfg.ResourceIdentifier+"/.well-known/oauth-protected-resource",
+					required,
+				),
+			)
 			w.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
-			return nil, err
+			return nil, fmt.Errorf("forbidden — insufficient scope")
 		}
 		return claims, nil
 	}
 
 	// v1: only check signature, then continue
-	if err := util.ValidateJWTOld(h); err != nil {
+	if err := util.ValidateJWTLegacy(h); err != nil {
 		return nil, err
 	}
 
@@ -352,7 +359,7 @@ func getAllowedOrigin(origin string, cfg *config.Config) string {
 func addCORSHeaders(w http.ResponseWriter, cfg *config.Config, allowedOrigin, requestHeaders string) {
 	w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
 	w.Header().Set("Access-Control-Allow-Methods", strings.Join(cfg.CORSConfig.AllowedMethods, ", "))
-	w.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate")
+	w.Header().Set("Access-Control-Expose-Headers", "WWW-Authenticate, MCP-Protocol-Version")
 	if requestHeaders != "" {
 		w.Header().Set("Access-Control-Allow-Headers", requestHeaders)
 	} else {
@@ -360,6 +367,7 @@ func addCORSHeaders(w http.ResponseWriter, cfg *config.Config, allowedOrigin, re
 	}
 	if cfg.CORSConfig.AllowCredentials {
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("MCP-Protocol-Version", ", ")
 	}
 	w.Header().Set("Vary", "Origin")
 	w.Header().Set("X-Accel-Buffering", "no")

--- a/internal/util/jwks.go
+++ b/internal/util/jwks.go
@@ -4,13 +4,21 @@ import (
 	"crypto/rsa"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/wso2/open-mcp-auth-proxy/internal/logging"
+	"github.com/wso2/open-mcp-auth-proxy/internal/authz"
+	"github.com/wso2/open-mcp-auth-proxy/internal/constants"
+	logger "github.com/wso2/open-mcp-auth-proxy/internal/logging"
 )
+
+type TokenClaims struct {
+	Scopes []string
+}
 
 type JWKS struct {
 	Keys []json.RawMessage `json:"keys"`
@@ -18,7 +26,7 @@ type JWKS struct {
 
 var publicKeys map[string]*rsa.PublicKey
 
-// FetchJWKS downloads JWKS and stores in a package-level map
+// FetchJWKS downloads JWKS and stores in a package‐level map
 func FetchJWKS(jwksURL string) error {
 	resp, err := http.Get(jwksURL)
 	if err != nil {
@@ -31,23 +39,23 @@ func FetchJWKS(jwksURL string) error {
 		return err
 	}
 
-	publicKeys = make(map[string]*rsa.PublicKey)
+	publicKeys = make(map[string]*rsa.PublicKey, len(jwks.Keys))
 	for _, keyData := range jwks.Keys {
-		var parsedKey struct {
+		var parsed struct {
 			Kid string `json:"kid"`
 			N   string `json:"n"`
 			E   string `json:"e"`
 			Kty string `json:"kty"`
 		}
-		if err := json.Unmarshal(keyData, &parsedKey); err != nil {
+		if err := json.Unmarshal(keyData, &parsed); err != nil {
 			continue
 		}
-		if parsedKey.Kty != "RSA" {
+		if parsed.Kty != "RSA" {
 			continue
 		}
-		pubKey, err := parseRSAPublicKey(parsedKey.N, parsedKey.E)
+		pk, err := parseRSAPublicKey(parsed.N, parsed.E)
 		if err == nil {
-			publicKeys[parsedKey.Kid] = pubKey
+			publicKeys[parsed.Kid] = pk
 		}
 	}
 	logger.Info("Loaded %d public keys.", len(publicKeys))
@@ -73,25 +81,121 @@ func parseRSAPublicKey(nStr, eStr string) (*rsa.PublicKey, error) {
 	return &rsa.PublicKey{N: n, E: e}, nil
 }
 
-// ValidateJWT checks the Authorization: Bearer token using stored JWKS
-func ValidateJWT(authHeader string) error {
-	if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
-		return errors.New("missing or invalid Authorization header")
-	}
+// ValidateJWT checks the Bearer token according to the Mcp-Protocol-Version.
+//   - versionHeader: the raw value of the "Mcp-Protocol-Version" header
+//   - authHeader:    the full "Authorization" header
+//   - audience:      the resource identifier to check "aud" against
+//   - requiredScope: the single scope required (empty ⇒ skip scope check)
+func ValidateJWT(
+	versionHeader, authHeader, audience, requiredScope string,
+) (*authz.TokenClaims, error) {
 	tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+	if tokenStr == "" {
+		return nil, errors.New("empty bearer token")
+	}
+
+	// 2) parse & verify signature
 	token, err := jwt.Parse(tokenStr, func(token *jwt.Token) (interface{}, error) {
 		kid, _ := token.Header["kid"].(string)
-		pubKey, ok := publicKeys[kid]
+		pk, ok := publicKeys[kid]
 		if !ok {
-			return nil, errors.New("unknown or missing kid in token header")
+			return nil, fmt.Errorf("unknown kid %q", kid)
 		}
-		return pubKey, nil
+		return pk, nil
 	})
+
+	logger.Info("token: %v", token)
+	logger.Info("err: %v", err)
+
 	if err != nil {
-		return errors.New("invalid token: " + err.Error())
+		return nil, fmt.Errorf("invalid token: %w", err)
 	}
 	if !token.Valid {
-		return errors.New("invalid token: token not valid")
+		return nil, errors.New("token not valid")
 	}
-	return nil
+
+	// always extract claims
+	claimsMap, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, errors.New("unexpected claim type")
+	}
+
+	// parse version date
+	verDate, err := time.Parse("2006-01-02", versionHeader)
+	if err != nil {
+		// if unparsable or missing, assume _old_ spec
+		verDate = time.Time{} // zero time ⇒ before cutover
+	}
+
+	// if older than cutover, skip audience+scope
+	if verDate.Before(constants.SpecCutoverDate) {
+		return &authz.TokenClaims{Scopes: nil}, nil
+	}
+
+	// --- new spec flow: enforce audience ---
+	audRaw, exists := claimsMap["aud"]
+	if !exists {
+		return nil, errors.New("aud claim missing")
+	}
+	switch v := audRaw.(type) {
+	case string:
+		if v != audience {
+			return nil, fmt.Errorf("aud %q does not match %q", v, audience)
+		}
+	case []interface{}:
+		var found bool
+		for _, a := range v {
+			if s, ok := a.(string); ok && s == audience {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("audience %v does not include %q", v, audience)
+		}
+	default:
+		return nil, errors.New("aud claim has unexpected type")
+	}
+
+	// if no scope required, we're done
+	if requiredScope == "" {
+		return &authz.TokenClaims{Scopes: nil}, nil
+	}
+
+	// enforce scope
+	rawScope, exists := claimsMap["scope"]
+	if !exists {
+		return nil, errors.New("scope claim missing")
+	}
+	scopeStr, ok := rawScope.(string)
+	if !ok {
+		return nil, errors.New("scope claim not a string")
+	}
+	scopes := strings.Fields(scopeStr)
+	for _, s := range scopes {
+		if s == requiredScope {
+			return &authz.TokenClaims{Scopes: scopes}, nil
+		}
+	}
+	return nil, fmt.Errorf("insufficient scope: %q not in %v", requiredScope, scopes)
+}
+
+// Performs basic JWT validation
+func ValidateJWTLegacy(authHeader string) error {
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+	_, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		kid, ok := token.Header["kid"].(string)
+		if !ok {
+			return nil, errors.New("kid header not found")
+		}
+		key, ok := publicKeys[kid]
+		if !ok {
+			return nil, fmt.Errorf("key not found for kid: %s", kid)
+		}
+		return key, nil
+	})
+	return err
 }

--- a/internal/util/rpc.go
+++ b/internal/util/rpc.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	logger "github.com/wso2/open-mcp-auth-proxy/internal/logging"
+)
+
+type RPCEnvelope struct {
+	Method string `json:"method"`
+	Params any    `json:"params"`
+	ID     any    `json:"id"`
+}
+
+// This function parses a JSON-RPC request from an HTTP request body
+func ParseRPCRequest(r *http.Request) (*RPCEnvelope, error) {
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	if len(bodyBytes) == 0 {
+		return nil, nil
+	}
+
+	var env RPCEnvelope
+	dec := json.NewDecoder(bytes.NewReader(bodyBytes))
+	if err := dec.Decode(&env); err != nil && err != io.EOF {
+		logger.Warn("Error parsing JSON-RPC envelope: %v", err)
+		return nil, err
+	}
+
+	logger.Info("JSON-RPC method = %q", env.Method)
+	return &env, nil
+}

--- a/internal/util/version.go
+++ b/internal/util/version.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"time"
+
+	"github.com/wso2/open-mcp-auth-proxy/internal/constants"
+)
+
+// This function checks if the given version date is after the spec cutover date
+func IsLatestSpec(versionDate time.Time, err error) bool {
+	return err == nil && !versionDate.Before(constants.SpecCutoverDate)
+}
+
+// This function parses a version string into a time.Time
+func ParseVersionDate(version string) (time.Time, error) {
+	return time.Parse("2006-01-02", version)
+}
+
+// This function returns the version string, using the cutover date if empty
+func GetVersionWithDefault(version string) string {
+	if version == "" {
+		return constants.SpecCutoverDate.Format("2006-01-02")
+	}
+	return version
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc. -->

The Open MCP Proxy currently implements MCP spec v1 (2024-11-06) only. This PR introduces high-level support for MCP spec v2 (2025-03-26) while preserving all existing v1 behaviour.

- Honour the MCP-Protocol-Version header (default to v1 when absent)
- Retain SSE transport for v1 and v2
- Validate v2 envelopes against the new JSON schema and enforce updated audience/scope rules
- Introduce a mcp_spec_v2 configuration block for new parameters (resource identifier, scopes, authorization servers, JWKS URI, bearer methods)
- Map MCP v2 error codes to HTTP status codes
- Expand README file with the latest specification requirements

## Related Issues

- https://github.com/wso2/open-mcp-auth-proxy/issues/29
